### PR TITLE
Initial Twitch Dashboard Video Layout

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,7 +5,7 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { HeaderComponent } from './header/header.component';
-import {MatButtonModule, MatCardModule, MatToolbarModule, MatTooltipModule} from '@angular/material';
+import {MatButtonModule, MatCardModule, MatGridListModule, MatToolbarModule, MatTooltipModule} from '@angular/material';
 import { LiveVideoComponent } from './twitch/live-video/live-video.component';
 import { TwitchDashboardComponent } from './twitch/twitch-dashboard/twitch-dashboard.component';
 
@@ -23,7 +23,8 @@ import { TwitchDashboardComponent } from './twitch/twitch-dashboard/twitch-dashb
     MatToolbarModule,
     MatButtonModule,
     MatTooltipModule,
-    MatCardModule
+    MatCardModule,
+    MatGridListModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/twitch/live-video/live-video.component.html
+++ b/src/app/twitch/live-video/live-video.component.html
@@ -1,13 +1,11 @@
-<mat-card class="live-video-card">
-  <mat-card-title class="card-title">{{channel}}</mat-card-title>
-  <mat-card-content class="embedded-video">
-    <iframe
-      [src]="safeUrl"
-      height="{{height}}"
-      width="{{width}}"
-      frameborder="0"
-      scrolling="no"
-      allowfullscreen="false">
-    </iframe>
-  </mat-card-content>
-</mat-card>
+<div #twitchContainer
+     class="twitch-iframe-container">
+  <iframe
+    [src]="safeUrl"
+    height="95%"
+    width="100%"
+    frameborder="0"
+    scrolling="no"
+    allowfullscreen="false">
+  </iframe>
+</div>

--- a/src/app/twitch/live-video/live-video.component.scss
+++ b/src/app/twitch/live-video/live-video.component.scss
@@ -12,3 +12,8 @@
     margin-bottom: 0.5em;
   }
 }
+
+.twitch-iframe-container {
+  height: 100%;
+  width: 100%;
+}

--- a/src/app/twitch/live-video/live-video.component.ts
+++ b/src/app/twitch/live-video/live-video.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnInit, SecurityContext} from '@angular/core';
+import {AfterViewInit, ChangeDetectorRef, Component, ElementRef, Input, OnInit, SecurityContext, ViewChild} from '@angular/core';
 import {DomSanitizer, SafeResourceUrl} from '@angular/platform-browser';
 
 @Component({
@@ -11,11 +11,12 @@ export class LiveVideoComponent implements OnInit {
   public safeUrl: SafeResourceUrl;
   @Input()
   public channel: string;
-  public height = 300;
-  // maintain a 3:4 ratio
-  public width = (this.height * 4) / 3;
 
-  constructor(private _domSanitizer: DomSanitizer) {
+  @ViewChild('twitchContainer', {static: false})
+  public twitchContainer: ElementRef;
+
+  constructor(private _domSanitizer: DomSanitizer,
+              private _changeDetectorRef: ChangeDetectorRef) {
   }
 
   ngOnInit() {
@@ -25,5 +26,4 @@ export class LiveVideoComponent implements OnInit {
       this._domSanitizer.sanitize(SecurityContext.URL, `https://player.twitch.tv/?channel=${this.channel}&muted=true`)
     );
   }
-
 }

--- a/src/app/twitch/twitch-dashboard/twitch-dashboard.component.html
+++ b/src/app/twitch/twitch-dashboard/twitch-dashboard.component.html
@@ -1,3 +1,14 @@
-<ng-container *ngFor="let channel of channels">
-  <app-live-video [channel]="channel"></app-live-video>
-</ng-container>
+<div class="grid-container">
+  <mat-grid-list cols="3" rowHeight="375px">
+    <mat-grid-tile *ngFor="let channel of sizedChannels" [colspan]="channel.cols" [rowspan]="channel.rows">
+      <mat-card class="dashboard-card">
+        <mat-card-title>
+          {{channel.channel}}
+        </mat-card-title>
+        <mat-card-content class="video-content">
+          <app-live-video [channel]="channel.channel"></app-live-video>
+        </mat-card-content>
+      </mat-card>
+    </mat-grid-tile>
+  </mat-grid-list>
+</div>

--- a/src/app/twitch/twitch-dashboard/twitch-dashboard.component.scss
+++ b/src/app/twitch/twitch-dashboard/twitch-dashboard.component.scss
@@ -1,0 +1,16 @@
+.grid-container {
+  margin: 20px;
+}
+
+.dashboard-card {
+  position: absolute;
+  top: 15px;
+  left: 15px;
+  right: 15px;
+  bottom: 15px;
+}
+
+.video-content {
+  height: 95%;
+  width: 100%;
+}

--- a/src/app/twitch/twitch-dashboard/twitch-dashboard.component.spec.ts
+++ b/src/app/twitch/twitch-dashboard/twitch-dashboard.component.spec.ts
@@ -1,8 +1,8 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 
-import { TwitchDashboardComponent } from './twitch-dashboard.component';
+import {TwitchDashboardComponent} from './twitch-dashboard.component';
 import {LiveVideoComponent} from '../live-video/live-video.component';
-import {MatCardModule} from '@angular/material';
+import {MatCardModule, MatGridListModule} from '@angular/material';
 
 describe('TwitchDashboardComponent', () => {
   let component: TwitchDashboardComponent;
@@ -10,10 +10,10 @@ describe('TwitchDashboardComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [ MatCardModule ],
-      declarations: [ TwitchDashboardComponent, LiveVideoComponent ]
+      imports: [MatCardModule, MatGridListModule],
+      declarations: [TwitchDashboardComponent, LiveVideoComponent]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {
@@ -24,5 +24,38 @@ describe('TwitchDashboardComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('when setting video cards on the dashboard', () => {
+
+    it('should make the first card on a desktop 3cols x 2rows', () => {
+      const result = component.setCardAndVideoSize('channel', 0, false);
+      expect(result.cols).toBe(3);
+      expect(result.rows).toBe(2);
+    });
+
+    it('should make the second card and beyond on a desktop 1cols x 1rows', () => {
+      const result = component.setCardAndVideoSize('channel', 1, false);
+      expect(result.cols).toBe(1);
+      expect(result.rows).toBe(1);
+    });
+
+    it('should make the first card on a phone 3cols x 1rows', () => {
+      const result = component.setCardAndVideoSize('channel', 0, true);
+      expect(result.cols).toBe(3);
+      expect(result.rows).toBe(1);
+    });
+
+    it('should make the second card and beyond on a phone 3cols x 1rows', () => {
+      const result = component.setCardAndVideoSize('channel', 1, true);
+      expect(result.cols).toBe(3);
+      expect(result.rows).toBe(1);
+    });
+
+    it('should not manipulate the channel name', () => {
+      const result = component.setCardAndVideoSize('channel', 0, false);
+      expect(result.channel).toBe('channel');
+    });
+
   });
 });

--- a/src/app/twitch/twitch-dashboard/twitch-dashboard.component.ts
+++ b/src/app/twitch/twitch-dashboard/twitch-dashboard.component.ts
@@ -1,6 +1,15 @@
 import {Component, OnDestroy, OnInit} from '@angular/core';
 import {ConfigurationService} from '../../config/configuration.service';
-import {Subscription} from 'rxjs';
+import {combineLatest, Observable, Subscription} from 'rxjs';
+import {BreakpointObserver, Breakpoints, BreakpointState} from '@angular/cdk/layout';
+import {map} from 'rxjs/operators';
+import {Configuration} from '../../config/configuration.model';
+
+interface TwitchCardMeasurements {
+  readonly channel: string;
+  readonly cols: 1 | 2 | 3;
+  readonly rows: 1 | 2;
+}
 
 @Component({
   selector: 'app-twitch-dashboard',
@@ -10,20 +19,62 @@ import {Subscription} from 'rxjs';
 export class TwitchDashboardComponent implements OnInit, OnDestroy {
 
   public channels: string[];
+  public sizedChannels: TwitchCardMeasurements[];
 
   private _subscription = new Subscription();
 
-  constructor(private _configurationService: ConfigurationService) { }
+  private configuration$: Observable<Configuration>;
+  private breakpoint$: Observable<BreakpointState>;
+
+  constructor(private _configurationService: ConfigurationService, private _breakpointObserver: BreakpointObserver) {
+  }
 
   ngOnInit() {
+    this.configuration$ = this._configurationService.configuration();
+    this.breakpoint$ = this._breakpointObserver.observe(Breakpoints.Handset);
+
     this._subscription.add(
-      this._configurationService.configuration()
+      this.configuration$
         .subscribe(value => this.channels = value.twitch.channels)
     );
+
+    this._subscription.add(
+      combineLatest([this.configuration$, this.breakpoint$]).pipe(
+        map(([configuration, breakpoint]) => ({configuration, breakpoint}))
+      ).subscribe(pair => {
+        const channels = pair.configuration.twitch.channels;
+        this.sizedChannels = channels.map(((value, index) => this.setCardAndVideoSize(value, index, pair.breakpoint.matches)));
+      }));
   }
 
   ngOnDestroy() {
     this._subscription.unsubscribe();
+  }
+
+  /**
+   * If the screen is small, make all cards the whole width and one row
+   * If the screen is larger, make the headlining card bigger and the rest small
+   * @param channel - the channel that will eventually be shown
+   * @param index - the channel's place on the dashboard
+   * @param isSmallScreen - whether or not we are on a phone
+   */
+  setCardAndVideoSize(channel: string, index: number, isSmallScreen: boolean): TwitchCardMeasurements {
+    let cols: 1 | 2 | 3;
+    let rows: 1 | 2;
+
+    if (isSmallScreen) {
+      cols = 3;
+      rows = 1;
+    } else {
+      cols = index === 0 ? 3 : 1;
+      rows = index === 0 ? 2 : 1;
+    }
+
+    return {
+      channel,
+      cols,
+      rows
+    };
   }
 
 }

--- a/src/assets/configuration/config.json
+++ b/src/assets/configuration/config.json
@@ -7,7 +7,13 @@
   "twitch": {
     "display": true,
     "channels": [
-      "NGeniusGaming"
+      "NGeniusGaming",
+      "CD_Mangaka",
+      "Dashr40",
+      "ICrazyJI",
+      "SetTopVox",
+      "RealSponge",
+      "studmanny"
     ]
   }
 }


### PR DESCRIPTION
use a mat-grid-list and a breakpoints observer to arrange the twitch video cards on the dashboard
the breakpoints observer dictates if we are on a desktop or a mobile phone, and adjusts the video cards accordingly.

Desktop:
![Desktop Layout](https://user-images.githubusercontent.com/8010983/72954696-7e14de00-3d56-11ea-94ca-b8242647b38a.png)

Mobile Phone:
![Phone Layout](https://user-images.githubusercontent.com/8010983/72954727-9ab11600-3d56-11ea-9c64-353db8de419d.png)

