### PR TITLE
Feature/add video pinning

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -2,20 +2,21 @@ import {NgModule} from '@angular/core';
 import {Routes, RouterModule} from '@angular/router';
 import {TwitchDashboardComponent} from './twitch/twitch-dashboard/twitch-dashboard.component';
 
+const home = '/team-view/twitch';
 
 const routes: Routes = [
   {
     path: 'team-view',
     children: [
       {path: 'twitch', component: TwitchDashboardComponent},
-      // empty paths and unknown paths in this sub-tree should redirect to twitch.
-      {path: '', redirectTo: '/team-view/twitch', pathMatch: 'full' },
-      {path: '**', redirectTo: '/team-view/twitch', pathMatch: 'full'}
+      // empty paths and unknown paths in this sub-tree should redirect to home.
+      {path: '', redirectTo: home, pathMatch: 'full' },
+      {path: '**', redirectTo: home, pathMatch: 'full'}
     ]
   },
-  // empty paths and unknown paths should redirect to /team-view
-  {path: '', redirectTo: '/team-view', pathMatch: 'full'},
-  {path: '**', redirectTo: '/team-view', pathMatch: 'full'}
+  // empty paths and unknown paths should redirect to home
+  {path: '', redirectTo: home, pathMatch: 'full'},
+  {path: '**', redirectTo: home, pathMatch: 'full'}
 ];
 
 @NgModule({

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,7 +5,7 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { HeaderComponent } from './header/header.component';
-import {MatButtonModule, MatCardModule, MatGridListModule, MatToolbarModule, MatTooltipModule} from '@angular/material';
+import {MatButtonModule, MatCardModule, MatGridListModule, MatIconModule, MatToolbarModule, MatTooltipModule} from '@angular/material';
 import { LiveVideoComponent } from './twitch/live-video/live-video.component';
 import { TwitchDashboardComponent } from './twitch/twitch-dashboard/twitch-dashboard.component';
 
@@ -24,7 +24,8 @@ import { TwitchDashboardComponent } from './twitch/twitch-dashboard/twitch-dashb
     MatButtonModule,
     MatTooltipModule,
     MatCardModule,
-    MatGridListModule
+    MatGridListModule,
+    MatIconModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/twitch/twitch-dashboard/twitch-dashboard.component.html
+++ b/src/app/twitch/twitch-dashboard/twitch-dashboard.component.html
@@ -1,9 +1,11 @@
 <div class="grid-container">
-  <mat-grid-list cols="3" rowHeight="375px">
+  <mat-grid-list cols="6" rowHeight="187.5px">
     <mat-grid-tile *ngFor="let channel of sizedChannels" [colspan]="channel.cols" [rowspan]="channel.rows">
       <mat-card class="dashboard-card">
-        <mat-card-title>
-          {{channel.channel}}
+        <mat-card-title class="card-title">
+          <span>{{channel.channel}}</span>
+          <span class="empty-space"></span>
+          <span><mat-icon [color]="isPinned(channel.channel)" (click)="pin(channel.channel)">star</mat-icon></span>
         </mat-card-title>
         <mat-card-content class="video-content">
           <app-live-video [channel]="channel.channel"></app-live-video>

--- a/src/app/twitch/twitch-dashboard/twitch-dashboard.component.scss
+++ b/src/app/twitch/twitch-dashboard/twitch-dashboard.component.scss
@@ -14,3 +14,11 @@
   height: 95%;
   width: 100%;
 }
+
+.card-title {
+  display: flex;
+}
+
+.empty-space {
+  flex: 1 1 auto;
+}

--- a/src/app/twitch/twitch-dashboard/twitch-dashboard.component.spec.ts
+++ b/src/app/twitch/twitch-dashboard/twitch-dashboard.component.spec.ts
@@ -2,7 +2,7 @@ import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {TwitchDashboardComponent} from './twitch-dashboard.component';
 import {LiveVideoComponent} from '../live-video/live-video.component';
-import {MatCardModule, MatGridListModule} from '@angular/material';
+import {MatCardModule, MatGridListModule, MatIconModule} from '@angular/material';
 
 describe('TwitchDashboardComponent', () => {
   let component: TwitchDashboardComponent;
@@ -10,7 +10,7 @@ describe('TwitchDashboardComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MatCardModule, MatGridListModule],
+      imports: [MatCardModule, MatGridListModule, MatIconModule],
       declarations: [TwitchDashboardComponent, LiveVideoComponent]
     })
       .compileComponents();
@@ -28,28 +28,28 @@ describe('TwitchDashboardComponent', () => {
 
   describe('when setting video cards on the dashboard', () => {
 
-    it('should make the first card on a desktop 3cols x 2rows', () => {
+    it('should make the first card on a desktop 6cols x 4rows', () => {
       const result = component.setCardAndVideoSize('channel', 0, false);
-      expect(result.cols).toBe(3);
+      expect(result.cols).toBe(6);
+      expect(result.rows).toBe(4);
+    });
+
+    it('should make the second card and beyond on a desktop 2cols x 2rows', () => {
+      const result = component.setCardAndVideoSize('channel', 1, false);
+      expect(result.cols).toBe(2);
       expect(result.rows).toBe(2);
     });
 
-    it('should make the second card and beyond on a desktop 1cols x 1rows', () => {
-      const result = component.setCardAndVideoSize('channel', 1, false);
-      expect(result.cols).toBe(1);
-      expect(result.rows).toBe(1);
-    });
-
-    it('should make the first card on a phone 3cols x 1rows', () => {
+    it('should make the first card on a phone 6cols x 2rows', () => {
       const result = component.setCardAndVideoSize('channel', 0, true);
-      expect(result.cols).toBe(3);
-      expect(result.rows).toBe(1);
+      expect(result.cols).toBe(6);
+      expect(result.rows).toBe(2);
     });
 
-    it('should make the second card and beyond on a phone 3cols x 1rows', () => {
+    it('should make the second card and beyond on a phone 6cols x 2rows', () => {
       const result = component.setCardAndVideoSize('channel', 1, true);
-      expect(result.cols).toBe(3);
-      expect(result.rows).toBe(1);
+      expect(result.cols).toBe(6);
+      expect(result.rows).toBe(2);
     });
 
     it('should not manipulate the channel name', () => {
@@ -57,5 +57,29 @@ describe('TwitchDashboardComponent', () => {
       expect(result.channel).toBe('channel');
     });
 
+  });
+
+  describe('when 2 channels are pinned to the top of the stream', () => {
+
+    beforeEach(() => {
+      component.pin('channel-one');
+      component.pin('channel-two');
+    });
+
+    it('should make the first two channels a bit smaller (3x3) when 2 are pinned', () => {
+      const result1 = component.setCardAndVideoSize('channel', 0, false);
+      const result2 = component.setCardAndVideoSize('channel', 1, false);
+      const result3 = component.setCardAndVideoSize('channel', 2, false);
+
+      expect(result1.cols).toBe(3);
+      expect(result1.rows).toBe(3);
+
+      expect(result2.cols).toBe(3);
+      expect(result2.rows).toBe(3);
+
+      // beyond the first 2, we are back to smaller cards.
+      expect(result3.cols).toBe(2);
+      expect(result3.rows).toBe(2);
+    });
   });
 });


### PR DESCRIPTION
Videos can be pinned (up to 2 at a time - most recent 2 are kept).

When 2 are pinned, they will split the top row.

Otherwise, a single pin will be moved to the top of the screen.

Things can also be un-pinned - only really noticeable if there were 2 pins.
-- Colors are still being ignored, uses material `accent` color for when they are pinned, or else no color --

-- Example of 2 things pinned.
![2 things pinned](https://user-images.githubusercontent.com/8010983/72960057-b671e780-3d69-11ea-9e83-6ef947028e44.png)

-- Example of 1 thing pinned.
![1 thing pinned](https://user-images.githubusercontent.com/8010983/72960139-f3d67500-3d69-11ea-9231-79dfcdfbc182.png)


