### PR TITLE
Feature/rework toggle

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -16,6 +16,7 @@ import { TwitchVideoOnlyComponent } from './twitch/twitch-video-only/twitch-vide
 import { TwitchVideoChatComponent } from './twitch/twitch-video-chat/twitch-video-chat.component';
 import { TwitchDashboardComponent } from './twitch/twitch-dashboard/twitch-dashboard.component';
 import {HttpClientModule} from '@angular/common/http';
+import {TwitchService} from './twitch/twitch.service';
 
 @NgModule({
   declarations: [

--- a/src/app/twitch/twitch-dashboard/twitch-card-measurements.model.ts
+++ b/src/app/twitch/twitch-dashboard/twitch-card-measurements.model.ts
@@ -1,0 +1,8 @@
+export type Column = 1 | 2 | 3 | 4 | 5 | 6;
+export type Row = 1 | 2 | 3 | 4;
+
+export interface TwitchCardMeasurements {
+  readonly channel: string;
+  readonly cols: Column;
+  readonly rows: Row;
+}

--- a/src/app/twitch/twitch-dashboard/twitch-dashboard.component.ts
+++ b/src/app/twitch/twitch-dashboard/twitch-dashboard.component.ts
@@ -5,22 +5,7 @@ import {BreakpointObserver, Breakpoints, BreakpointState} from '@angular/cdk/lay
 import {map} from 'rxjs/operators';
 import {ThemePalette} from '@angular/material';
 import {TwitchService} from '../twitch.service';
-
-type Column = 1 | 2 | 3 | 4 | 5 | 6;
-type Row = 1 | 2 | 3 | 4;
-
-
-interface TwitchCardMeasurements {
-  readonly channel: string;
-  readonly cols: Column;
-  readonly rows: Row;
-}
-
-export interface ChatCardMeasurments {
-  gridName: string;
-  cols: number;
-  rows: number;
-}
+import {Column, Row, TwitchCardMeasurements} from './twitch-card-measurements.model';
 
 @Component({
   selector: 'app-twitch-dashboard',
@@ -29,7 +14,7 @@ export interface ChatCardMeasurments {
 })
 export class TwitchDashboardComponent implements OnInit, OnDestroy {
 
-  public sizedChannels: TwitchCardMeasurements[];
+  private sizedChannels: TwitchCardMeasurements[];
 
   private _subscription = new Subscription();
 
@@ -45,39 +30,43 @@ export class TwitchDashboardComponent implements OnInit, OnDestroy {
   ngOnInit() {
 
     this.breakpoint$ = this._breakpointObserver.observe(Breakpoints.Handset);
+    this._breakpointObserver.observe(Breakpoints.Handset).subscribe(v => console.log(v));
 
     this._subscription.add(
       combineLatest([this._twitchService.channels(), this.breakpoint$]).pipe(
         map(([channels, breakpoint]) => ({channels, breakpoint}))
       ).subscribe(pair => {
-        const channels = pair.channels;
+        console.log('test');
+        const channels = [...pair.channels];
         const newSizedChannels = channels.map(((value, index) => this.setCardAndVideoSize(value, index, pair.breakpoint.matches)));
-        if (channels.length !== newSizedChannels.length || JSON.stringify(this.sizedChannels) !== JSON.stringify(newSizedChannels)) {
+        if (JSON.stringify(this.sizedChannels) !== JSON.stringify(newSizedChannels)) {
           // if the sized channels have changed in some way, re-set them, which causes them to reload.
           this.sizedChannels = newSizedChannels;
+          this._resortChannels();
         }
       }));
+
   }
 
   ngOnDestroy() {
     this._subscription.unsubscribe();
   }
 
-  /**
-   * Pin a new channel - only the last 2 channels pinned are kept.
-   * After the pinned channels are calculated, sort and re-emit the ordered channels.
-   *
-   * @param channel to pin
-   */
-  pin(channel: string) {
-    const index = this._pinnedChannels.indexOf(channel);
+  public pin(channel: string) {
+    let currentPins = [...this._pinnedChannels];
+    const index = currentPins.indexOf(channel);
     if (index > -1) {
       // remove the item from the pinned channels
-      this._pinnedChannels.splice(index, 1);
+      currentPins.splice(index, 1);
     } else {
       // add the channel to the front of the array
-      this._pinnedChannels = [channel, ...this._pinnedChannels.slice(0, 1)];
+      currentPins = [channel, ...currentPins.slice(0, 1)];
     }
+    this._pinnedChannels = currentPins;
+    this._resortChannels();
+  }
+
+  private _resortChannels() {
     const sortedChannels = [...this.sizedChannels]
       .map(value => value.channel)
       .sort((a, b) => this.weightOfPin(b) - this.weightOfPin(a));

--- a/src/app/twitch/twitch-dashboard/twitch-dashboard.component.ts
+++ b/src/app/twitch/twitch-dashboard/twitch-dashboard.component.ts
@@ -1,6 +1,6 @@
 import {Component, OnDestroy, OnInit} from '@angular/core';
 import {ConfigurationService} from '../../config/configuration.service';
-import {combineLatest, Observable, Subscription} from 'rxjs';
+import {BehaviorSubject, combineLatest, Observable, Subscription} from 'rxjs';
 import {BreakpointObserver, Breakpoints, BreakpointState} from '@angular/cdk/layout';
 import {map} from 'rxjs/operators';
 import {ThemePalette} from '@angular/material';
@@ -14,13 +14,18 @@ import {Column, Row, TwitchCardMeasurements} from './twitch-card-measurements.mo
 })
 export class TwitchDashboardComponent implements OnInit, OnDestroy {
 
-  private sizedChannels: TwitchCardMeasurements[];
+  public sizedChannels: TwitchCardMeasurements[];
 
   private _subscription = new Subscription();
 
   private _pinnedChannels: string[] = [];
 
   private breakpoint$: Observable<BreakpointState>;
+
+  /**
+   * Used to force a refresh of the dashboard.
+   */
+  private _refreshView: BehaviorSubject<undefined> = new BehaviorSubject<undefined>(undefined);
 
   constructor(private _configurationService: ConfigurationService,
               private _twitchService: TwitchService,
@@ -30,20 +35,17 @@ export class TwitchDashboardComponent implements OnInit, OnDestroy {
   ngOnInit() {
 
     this.breakpoint$ = this._breakpointObserver.observe(Breakpoints.Handset);
-    this._breakpointObserver.observe(Breakpoints.Handset).subscribe(v => console.log(v));
 
     this._subscription.add(
-      combineLatest([this._twitchService.channels(), this.breakpoint$]).pipe(
-        map(([channels, breakpoint]) => ({channels, breakpoint}))
-      ).subscribe(pair => {
-        console.log('test');
-        const channels = [...pair.channels];
-        const newSizedChannels = channels.map(((value, index) => this.setCardAndVideoSize(value, index, pair.breakpoint.matches)));
-        if (JSON.stringify(this.sizedChannels) !== JSON.stringify(newSizedChannels)) {
-          // if the sized channels have changed in some way, re-set them, which causes them to reload.
-          this.sizedChannels = newSizedChannels;
-          this._resortChannels();
-        }
+      combineLatest(
+        [this._twitchService.channels(),
+          this._twitchService.showingOfflineStreams(),
+          this.breakpoint$, this._refreshView]
+      ).pipe(
+        map(([channels, showingOfflineStreams, breakpoint, refresh]) => ({channels, showingOfflineStreams, breakpoint, refresh}))
+      ).subscribe(data => {
+        const channels = this._twitchService.filteredChannels(data.channels, data.showingOfflineStreams);
+        this._updateChannelsView(channels, data.breakpoint);
       }));
 
   }
@@ -63,14 +65,17 @@ export class TwitchDashboardComponent implements OnInit, OnDestroy {
       currentPins = [channel, ...currentPins.slice(0, 1)];
     }
     this._pinnedChannels = currentPins;
-    this._resortChannels();
+    this._refreshView.next(undefined);
   }
 
-  private _resortChannels() {
-    const sortedChannels = [...this.sizedChannels]
-      .map(value => value.channel)
-      .sort((a, b) => this.weightOfPin(b) - this.weightOfPin(a));
-    this._twitchService.reorderedChannels(sortedChannels);
+  private _updateChannelsView(channels: string[], breakpoint: BreakpointState) {
+    // first, resort the channels
+    const updatedChannels = [...channels].sort((a, b) => this.weightOfPin(b) - this.weightOfPin(a))
+      .map(((value, index) => this.setCardAndVideoSize(value, index, breakpoint.matches)));
+    if (JSON.stringify(this.sizedChannels) !== JSON.stringify(updatedChannels)) {
+      // if the sized channels have changed in some way, re-set them, which causes them to reload.
+      this.sizedChannels = updatedChannels;
+    }
   }
 
   /**

--- a/src/app/twitch/twitch-video-chat/twitch-video-chat.component.ts
+++ b/src/app/twitch/twitch-video-chat/twitch-video-chat.component.ts
@@ -1,5 +1,4 @@
-import {AfterViewInit, ChangeDetectorRef, Component, ElementRef, Input, OnInit, ViewChild} from '@angular/core';
-import {DomSanitizer} from '@angular/platform-browser';
+import {AfterViewInit, Component, ElementRef, Input, OnInit, ViewChild} from '@angular/core';
 
 declare const Twitch: any;
 
@@ -16,8 +15,7 @@ export class TwitchVideoChatComponent implements OnInit, AfterViewInit {
   @ViewChild('twitchContainer', {static: false})
   public twitchContainer: ElementRef;
 
-  constructor(private _domSanitizer: DomSanitizer,
-              private _changeDetectorRef: ChangeDetectorRef) {
+  constructor() {
   }
 
   ngOnInit() {
@@ -25,12 +23,13 @@ export class TwitchVideoChatComponent implements OnInit, AfterViewInit {
   }
 
   ngAfterViewInit() {
+    console.log('channel %s', this.channel);
     const options = {
       width: '100%',
       height: '100%',
       channel: this.channel
     };
     const player = new Twitch.Embed(this.channel, options);
-    player.setVolume(0.5);
+    // player.setVolume(0.5);
   }
 }


### PR DESCRIPTION
Should squash the bugs with the twitch dashboard.

Separates filtering _out_ of the twitch service.
    The twitch service must be responsible for the _complete_ data set.
    Consuming components can filter and slice that data however they please.